### PR TITLE
init/frontend : Installation de React-Hook-Form

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.1.1",
         "sass": "^1.83.0"
       },
@@ -4862,6 +4863,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.1",
     "sass": "^1.83.0"
   },

--- a/client/src/components/FormTest.jsx
+++ b/client/src/components/FormTest.jsx
@@ -1,0 +1,48 @@
+import { useForm } from "react-hook-form";
+
+function FormTest() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log("Form Data:", data);
+    alert("Formulaire soumis avec succès !");
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label htmlFor="name">Nom :</label>
+        <input
+          id="name"
+          type="text"
+          {...register("name", { required: "Le nom est obligatoire" })}
+        />
+        {errors.name && <p style={{ color: "red" }}>{errors.name.message}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="email">Email :</label>
+        <input
+          id="email"
+          type="email"
+          {...register("email", {
+            required: "L’email est obligatoire",
+            pattern: {
+              value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+              message: "Adresse email invalide",
+            },
+          })}
+        />
+        {errors.email && <p style={{ color: "red" }}>{errors.email.message}</p>}
+      </div>
+
+      <button type="submit">Soumettre</button>
+    </form>
+  );
+}
+
+export default FormTest;

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -9,4 +9,15 @@ body {
 h1 {
   text-align: center;
   margin-top: 20px;
+}
+
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #256c9b;
+}
+.container h1 {
+  font-size: 2rem;
 }/*# sourceMappingURL=main.css.map */

--- a/client/src/styles/main.css.map
+++ b/client/src/styles/main.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["main.scss","main.css"],"names":[],"mappings":"AAEA;EACE,8BAAA;EACA,yBAJc;EAKd,WAAA;EACA,SAAA;EACA,UAAA;ACDF;;ADIA;EACE,kBAAA;EACA,gBAAA;ACDF","file":"main.css"}
+{"version":3,"sources":["main.scss","main.css"],"names":[],"mappings":"AAEA;EACE,8BAAA;EACA,yBAJc;EAKd,WAAA;EACA,SAAA;EACA,UAAA;ACDF;;ADIA;EACE,kBAAA;EACA,gBAAA;ACDF;;ADUA;EALE,aAAA;EACA,uBAAA;EACA,mBAAA;EAKA,aAAA;EACA,yBAAA;ACLF;ADOE;EACE,eAAA;ACLJ","file":"main.css"}

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -12,3 +12,19 @@ h1 {
   text-align: center;
   margin-top: 20px;
 }
+
+@mixin center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.container {
+  @include center;
+  height: 100vh;
+  background-color: lighten($primary-color, 10%);
+
+  h1 {
+    font-size: 2rem;
+  }
+}

--- a/client/src/tests/FormTest.test.jsx
+++ b/client/src/tests/FormTest.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import FormTest from "../components/FormTest";
+
+global.alert = vi.fn(); // Simule window.alert
+
+test("submits the form with valid inputs", async () => {
+  await act(async () => {
+    render(<FormTest />);
+  });
+
+  // Remplis les champs
+  fireEvent.input(screen.getByLabelText(/Nom/i), {
+    target: { value: "Romain" },
+  });
+  fireEvent.input(screen.getByLabelText(/Email/i), {
+    target: { value: "romain@test.com" },
+  });
+
+  // Soumets le formulaire
+  await act(async () => {
+    fireEvent.click(screen.getByText(/Soumettre/i));
+  });
+
+  // Vérifie que l'alerte a été appelée
+  expect(global.alert).toHaveBeenCalledWith("Formulaire soumis avec succès !");
+});

--- a/client/src/views/Home.jsx
+++ b/client/src/views/Home.jsx
@@ -1,7 +1,12 @@
+import FormTest from "../components/FormTest";
+
 const Home = () => {
   return (
     <>
       <h1>Bienvenue sur EcoRide</h1>
+      <div className="container">
+        <FormTest />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
# 03/01/2025 19:36

## Tâches

- Installation de `react-hook-form`
- Création d'un formulaire de test  `FormTest.jsx` appelé dans `Home.jsx`
- Création de d'un **test** : `src` → `test` → `FormTest.test.jsx`

## Indications

`react-hook-form` sera utilisé pour géré tous les formulaires de l'application.